### PR TITLE
Update THE9.sol

### DIFF
--- a/THE9.sol
+++ b/THE9.sol
@@ -1,7 +1,3 @@
-/**
- *Submitted for verification at Etherscan.io on 2021-10-16
-*/
-
 // SPDX-License-Identifier: MIT
 
 
@@ -1307,12 +1303,19 @@ contract THE9 is ERC20, Pausable, AccessControl {
     function unpause() public onlyRole(PAUSER_ROLE) {
         _unpause();
     }
-
+    
+    function burn(address account, uint256 amount) public onlyRole(ORG_ADMIN_ROLE) {
+        _burn(account, _calcDecimal(amount));
+    }
+    
     function createAmountWithLock(address beneficiary, uint256 amount, uint256 firstReleaseTime, uint256 unlockPercent, uint256 lockCycleDays)
         public
         whenNotPaused
         onlyRole(ORG_ADMIN_ROLE) 
     {
+        if (firstReleaseTime == 0) {
+            firstReleaseTime = DEFAULT_RELEASE_TIMESTAMP;
+        }
         assert(_beforeSaveAmountWithLock(beneficiary, firstReleaseTime, unlockPercent, lockCycleDays));
         
         if (_checkExists(beneficiary)) {
@@ -1339,6 +1342,10 @@ contract THE9 is ERC20, Pausable, AccessControl {
         onlyRole(ORG_ADMIN_ROLE) 
     {
         require(_checkExists(beneficiary), "THE9: beneficiary not found");
+        
+        if (firstReleaseTime == 0) {
+            firstReleaseTime = DEFAULT_RELEASE_TIMESTAMP;
+        }
         assert(_beforeSaveAmountWithLock(beneficiary, firstReleaseTime, unlockPercent, lockCycleDays));
         
         BeneficiaryInfo memory beforeInfo = _getInfo(beneficiary);
@@ -1372,6 +1379,7 @@ contract THE9 is ERC20, Pausable, AccessControl {
         // check timestamp
         BeneficiaryInfo memory beforeInfo = _getInfo(beneficiary);
         require(_isReleased(beneficiary), "THE9: It hasn't been released yet");
+        require(beforeInfo.remainAmount > 0, "THE9: No remaining amount");
 
         // remainAmount
         uint256 remainAmount = beforeInfo.remainAmount;
@@ -1457,10 +1465,6 @@ contract THE9 is ERC20, Pausable, AccessControl {
         require(unlockPercent > 0, "THE9: percentage cannot be zero");
         require(unlockPercent <= 100, "THE9: percentage cannot exceed 100");
         require(lockCycleDays > 0, "THE9: lock cycle days cannot be zero");
-        
-        if (firstReleaseTime == 0) {
-            firstReleaseTime = DEFAULT_RELEASE_TIMESTAMP;
-        }
         require(firstReleaseTime > block.timestamp, "THE9: first release time is before current time");
         
         return true;


### PR DESCRIPTION
[Major]
THE9#BeneficiaryInfo의 Release time이 0으로 설정될 수 있습니다.(Found - v.1.0)
    -> solution
        1) createAmountWithLock, updateAmountWithLock 시 firstReleaseTime이 0으로 입력되면 DEFAULT_RELEASE_TIMESTAMP로 세팅하는 로직 추가


[Minor]
THE9#createAmountWithLock() 함수가 기존 THE9#BeneficiaryInfo 정보를 변경할 수 있습니다.(Found - v.1.0)
    -> solution
        1) 의도된 사항으로 수정사항 없음

THE9#transferAmountWithLock() 함수의 반복적인 호출이 불필요하게 요구될 수 있습니다.(Found - v.1.0)
    -> solution
        1) 의도된 사항으로 수정사항 없음

더이상 전송할 수 있는 토큰이 없어도 THE9#transferAmountWithLock() 함수가 정상 실행 됩니다.(Found - v.1.0)
    -> solution
        1) 잔여 토큰 갯수 체크하는 require 문 추가


[Tips]
UpdateAmountWithLock Event 정보가 충분하지 않습니다.(Found - v.1.0)
    -> solution
        1) 입력된 값의 정보를 알고있으므로 의도된 사항

사용되지 않는 함수가 있습니다.(Found - v.1.0)
    -> solution
        1) Context#_msgData() : 외부 컨트랙트 사용으로 버전상 무결성 유지 차원에서 미사용 소스 유지.
        2) ERC20#_burn() : THE9 Contract에서 burn public 함수 구현